### PR TITLE
checking if the error just was the node version of render

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# EDT test, api REST for melp
+
+
+https://edt-melp-api.onrender.com/
+
 <p align="center">
   <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="200" alt="Nest Logo" /></a>
 </p>

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "^5.4.1",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1",
-    "@nestjs/cli": "^10.0.0"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
     "@types/express": "^4.17.17",
@@ -68,5 +68,8 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "engines": {
+    "node": ">=16.13"
   }
 }


### PR DESCRIPTION
I get a error deploying to render, they use the node version 14 by default and the prisma/client it's compatible, so I change the version for 18.17.1 the same I have on local and I add the engines specification on the pckage.json to prevent this error again.
This branch it's running well on render so I'm good to merge.